### PR TITLE
Fixed incorrect Python version requirement for importlib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     requests
-    importlib; python_version <= "3.7"
+    importlib; python_version < "3.1"
 zip_safe = True
 
 [options.extras_require]


### PR DESCRIPTION
importlib was [added in Python 3.1](https://docs.python.org/3.1/whatsnew/3.1.html), so setup.cfg should only require Python to be 3.1 or newer. 