### PR TITLE
Suggest swclient and version in README, pydocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Import the dnsdb2 library and configure a client.
 
 ```python
 import dnsdb2
-client = dnsdb2.Client(apikey)
+client = dnsdb2.Client(apikey, swclient="yourappname", version="v0.0")
 ```
 
 Perform a flex regex search for `farsight`. This manually suppresses `QueryLimited` exceptions raised by the server if the query results exceed the row limited.

--- a/dnsdb2/client.py
+++ b/dnsdb2/client.py
@@ -15,7 +15,7 @@
 # A client for DNSDB protocol version 2 with Flex Search.
 #
 # Example:
-#     c = dnsdb2.Client(apikey)
+#     c = dnsdb2.Client(apikey, swclient="yourappname", version="v0.0")
 #     try:
 #        for result in c.flex_rrnames_regex(r'\._dkim\.', limit=1):
 #            # do something with result
@@ -300,7 +300,7 @@ class Client(object):
     A client for DNSDB protocol version 2 with Flex Search.
 
     Example:
-        c = dnsdb2.Client(apikey)
+        c = dnsdb2.Client(apikey, swclient="yourappname", version="v0.0")
         try:
             for result in c.flex_rrnames_regex(r'\\._dkim\\.', limit=1):
                 # do something with result


### PR DESCRIPTION
This commit adds swclient and version parameters to example usage of
Client to encourage users to make use of those parameters so that
clients are more easily identifiable in log data.