### PR TITLE
IDEV-2115 DNSDB Update

### DIFF
--- a/dnsdb2/client.py
+++ b/dnsdb2/client.py
@@ -309,7 +309,7 @@ class Client(object):
     """
     def __init__(self, apikey: str, server: str = DEFAULT_DNSDB_SERVER,
                  swclient: str = DEFAULT_SWCLIENT, version: str = DEFAULT_VERSION,
-                 proxies: Dict[str, str] = None, verify: Union[str, bool, None] = None):
+                 proxies: Dict[str, str] = None, insecure: bool = False, verify: Union[str, bool, None] = None):
         """
         Args:
             apikey (str): A DNSDB API key
@@ -317,6 +317,7 @@ class Client(object):
             swclient (str): The name of the client software reported to DNSDB.
             version (str): The version of the software reported to DNSDB.
             proxies (Dict[str, str]): HTTP proxies to use. Mapping of protocol to URL.
+            insecure (bool): Skip https validation.
             verify (str): Either a boolean, in which case it controls whether we verify the server’s TLS certificate, or a string, in which case it must be a path to a CA bundle to use.
         """
         self.apikey = apikey
@@ -324,6 +325,7 @@ class Client(object):
         self.swclient = swclient
         self.version = version
         self.proxies = proxies
+        self.insecure = insecure
         self.verify = verify
         self._session = requests.Session()
 
@@ -384,7 +386,7 @@ class Client(object):
                                    params=query_params,
                                    headers=self._headers(),
                                    proxies=self.proxies,
-                                   verify=self.verify,
+                                   verify=False if self.insecure else self.verify,
                                    ) as res:
                 _raise_error(res)
                 return res.json()
@@ -403,7 +405,7 @@ class Client(object):
                 headers=self._headers(),
                 params=query_params,
                 proxies=self.proxies,
-                verify=self.verify,
+                verify=False if self.insecure else self.verify,
                 stream=True,
             )
 


### PR DESCRIPTION
Add support for custom cert by adding replacing the `insecure` param with the `verify` param. To be used the same way as it is in the `requests` lib.

Tested and verified in our Splunk environment.